### PR TITLE
Allow configuration of line end character when sending single lines

### DIFF
--- a/plugin/send-to-term.vim
+++ b/plugin/send-to-term.vim
@@ -30,7 +30,7 @@ function! s:SendLinesToTerm(lines) dict
     if len(a:lines) > 1
         let line = self.begin . join(a:lines, self.newline) . self.end
     else
-        let line = a:lines[0] . "\n"
+        let line = self.begin . a:lines[0] . self.end
     endif
     call jobsend(self.term_id, line)
     " If sending over multiple commands ([count]ss), slow down a little to


### PR DESCRIPTION
When using this plugin with Neovim under Windows, the \n newline character will not correctly execute a line of code in the Python Repl. In Windows, we need to use \r for that.

When sending multiple lines of text this is configurable by g:send_multiline, but this setting is ignored when sending a single line. In order to execute a single line of code you must manually activate the terminal pane and press enter.

By changing a line of code to use the 'begin' and 'end' keys defined in g:send_multiline, single line sends now work as desired.