### PR TITLE
chansend instead of jobsend

### DIFF
--- a/plugin/send-to-term.vim
+++ b/plugin/send-to-term.vim
@@ -41,7 +41,7 @@ function! s:SendLinesToTerm(lines) dict
     else
         let line = a:lines[0] . s:nl
     endif
-    call jobsend(self.term_id, line)
+    call chansend(self.term_id, line)
     " If sending over multiple commands ([count]ss), slow down a little to
     " let some REPLs catch up (IPython, basically)
     if v:count1 > 1


### PR DESCRIPTION
jobsend() is been superseeded by chansend() in neovim (changed in https://github.com/neovim/neovim/commit/5af47031773fc647de867444693d1598d0da458d).